### PR TITLE
adjust dependencies for forward compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,33 +12,28 @@
     "type": "git",
     "url": "https://github.com/h0tw4t3r/react-soundcloud-embedded.git"
   },
-  "keywords": [
-    "react",
-    "reactjs",
-    "soundcloud"
-  ],
+  "keywords": ["react", "reactjs", "soundcloud"],
   "author": "Andrey Keske <hello@andreykeske.com> (https://github.com/keske)",
-  "contributors": [
-    "Vladyslav Dalechyn <hotwater438@tutanota.com> (https://github.com/hotwater)"
-  ],
+  "contributors": ["Vladyslav Dalechyn <hotwater438@tutanota.com> (https://github.com/hotwater)"],
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/h0tw4t3r/react-soundcloud-embedded/issues"
   },
   "homepage": "https://github.com/h0tw4t3r/react-soundcloud-embedded",
   "devDependencies": {
+    "@types/node": "^14.0.11",
+    "@types/react": "^16.9.35",
     "@typescript-eslint/eslint-plugin": "^3.1.0",
     "@typescript-eslint/parser": "^3.1.0",
     "eslint": "^7.2.0",
     "eslint-config-prettier": "^6.11.0",
     "eslint-plugin-prettier": "^3.1.3",
     "eslint-plugin-react": "^7.20.0",
-    "prettier": "^2.0.5"
+    "prettier": "^2.0.5",
+    "typescript": "^3.9.5",
+    "react": "^16.13.1"
   },
-  "dependencies": {
-    "@types/node": "^14.0.11",
-    "@types/react": "^16.9.35",
-    "react": "^16.13.1",
-    "typescript": "^3.9.5"
+  "peerDependencies": {
+    "react": "^16.13.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -965,7 +965,16 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2:
+  version "15.8.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
+  integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
+  dependencies:
+    loose-envify "^1.4.0"
+    object-assign "^4.1.1"
+    react-is "^16.13.1"
+
+prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -979,15 +988,15 @@ punycode@^2.1.0:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-react-is@^16.8.1:
+react-is@^16.13.1, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
 
 react@^16.13.1:
-  version "16.13.1"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.13.1.tgz#2e818822f1a9743122c063d6410d85c1e3afe48e"
-  integrity sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==
+  version "16.14.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
+  integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"


### PR DESCRIPTION
When installing this component in React 18, using TypeScript, warnings appear
in your editor since this package depends on `@types/react` directly. This is
only necessary for the build environment, and shouldn't be included in a
package's dependencies as it can confuse TypeScript at the application level.

This adjustment to the dependencies still lints and builds just fine, but the
package itself will no longer depend on anything at runtime, allowing usage of
the component in any future version of React.
